### PR TITLE
fix: verify cluster existence check works correctly

### DIFF
--- a/helm/task-manager/Chart.yaml
+++ b/helm/task-manager/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: task-manager
 description: Task Manager API (Go + Postgres)
 type: application
-version: 0.5.0
-appVersion: "1.4.0"
+version: 0.5.1
+appVersion: "1.4.1"


### PR DESCRIPTION
Test that the cluster existence check handles missing GKE cluster gracefully.